### PR TITLE
Add clickable links to tutorial references

### DIFF
--- a/Tutorials/DeepDives/ConfigTutorial.ipynb
+++ b/Tutorials/DeepDives/ConfigTutorial.ipynb
@@ -79,7 +79,7 @@
     "We can easily load the values into our config class with the `model_validate` method, as shown below:\n",
     "\n",
     "#### ❗❗ Requirements: Getting Tutorial Data ❗❗\n",
-    "To follow along, please download the date from the link below (1GB), if you've already done the `Ontix` Tutorial, you've probably already downloaded the data.\n",
+    "To follow along, please download the date from the link below (1GB), if you've already done the [`Ontix` Tutorial](../PipelineTutorials/Ontix.ipynb), you've probably already downloaded the data.\n",
     "\n",
     "https://cloud.scadsai.uni-leipzig.de/index.php/s/QXYnieKY8AA3Zta/download/OntixTutorialData.zip\n",
     "\n",
@@ -89,7 +89,7 @@
     "\n",
     "### Extra 2: Get correct path\n",
     "We assume you are in the root of the package. The following code ensures that the correct paths are used.\n",
-    "[1] Tutorials/DeepDives/ConfigTutorial.ipynb\n"
+    "[1] [Tutorials/DeepDives/ConfigTutorial.ipynb](./ConfigTutorial.ipynb)\n"
    ]
   },
   {

--- a/Tutorials/DeepDives/EvaluateTutorial.ipynb
+++ b/Tutorials/DeepDives/EvaluateTutorial.ipynb
@@ -1653,7 +1653,7 @@
     "## Pure VAE comparison\n",
     "The function `xmodalix.evaluator.pure_vae_comparison()` is designed to evaluate the reconstruction capability of a XModalix (reference and translated) against a normal Imagix on the image target modality. This evaluation provides insights whether the enforced latent space alignment and coupled training in the XModalix decreases or improves the reconstruction capability in comparison to image-only autoencoder. \n",
     "\n",
-    "The prerequisite for this comparison is the prior training of an imagix. An example is provided in the XModalix tutorial. \n"
+    "The prerequisite for this comparison is the prior training of an imagix. An example is provided in the [XModalix tutorial](../PipelineTutorials/XModalix.ipynb). \n"
    ]
   },
   {

--- a/Tutorials/DeepDives/ExplainStep.ipynb
+++ b/Tutorials/DeepDives/ExplainStep.ipynb
@@ -30,7 +30,7 @@
     "\n",
     "#### Extra 2: Get correct path\n",
     "We assume you are in the root of the package. The following code ensures that the correct paths are used.\n",
-    "[1] Tutorials/DeepDives/ConfigTutorial.ipynb\n"
+    "[1] [Tutorials/DeepDives/ConfigTutorial.ipynb](./ConfigTutorial.ipynb)\n"
    ]
   },
   {
@@ -94,7 +94,7 @@
    "source": [
     "### 2a) Creating a synthetic ground truth\n",
     "Feature importance by attribution scores is hard to quantify for its performance and reliability of outcome. Hence, we will introduce in this tutorial a little synthetic signal on selected genes of a specific chromosome only for a group of sample to check if they will be picked up by our xAI method.\n",
-    "Hence, we will alter the gene expression and methylation intensities of some genes of the 21 Chromosome only for 'male' samples (compare also Ontix tutorial)."
+    "Hence, we will alter the gene expression and methylation intensities of some genes of the 21 Chromosome only for 'male' samples (compare also [Ontix tutorial](../PipelineTutorials/Ontix.ipynb))."
    ]
   },
   {

--- a/Tutorials/DeepDives/InputDataTutorials.ipynb
+++ b/Tutorials/DeepDives/InputDataTutorials.ipynb
@@ -78,7 +78,7 @@
     "**IMPORTANT:**  \n",
     "> For all your bulk data files, we expect the first column to be some kind of unique sample ID. Please prepare the data accordingly.\n",
     "\n",
-    "[1] `Tutorials/DeepDives/ConfigTutorial.ipynb`\n"
+    "[1] [`Tutorials/DeepDives/ConfigTutorial.ipynb`](./ConfigTutorial.ipynb)\n"
    ]
   },
   {

--- a/Tutorials/DeepDives/PipelineOutputTutorial.ipynb
+++ b/Tutorials/DeepDives/PipelineOutputTutorial.ipynb
@@ -49,7 +49,7 @@
     "### 1.1 The Datasets\n",
     "\n",
     "For the `Varix` example, we use a mock single-cell dataset as a `MuData` object inside our custom `DataPackage` class.  \n",
-    "For our `XModalix` example, we use the same dataset as in the `XModalix.ipynb` tutorial.  \n",
+    "For our `XModalix` example, we use the same dataset as in the [`XModalix.ipynb`](../PipelineTutorials/XModalix.ipynb) tutorial.  \n",
     "\n",
     "As a showcase for data modality translation with `XModalix`, we use cancer gene expression from TCGA in combination with handwritten digits from the [MNIST dataset](https://keras.io/api/datasets/mnist/).  \n",
     "Our goal is to translate the gene expression signature of five selected cancer subtypes to images of digits, where each cancer subtype class is assigned a digit between 0-4.  \n",

--- a/Tutorials/DeepDives/VisualizeTutorial.ipynb
+++ b/Tutorials/DeepDives/VisualizeTutorial.ipynb
@@ -1267,7 +1267,7 @@
     "1. `xmodalix.visualizer.show_2D_translation()` - This plot compares on the test-split the `translated_modality` reconstruction by the XModalix with the original input in joint 2D repesentation calculated used a specified `reducer` method (default `UMAP`). A well trained XModalix and good translated modality (right plot) should as similar as possible to the original input (left plot). \n",
     "2. `xmodalix.visualizer.show_image_translation()` - For images as target modality of translation, translation capability can be checked by visual comparison of test samples, possibly across classes specified under `param`, from a) original b) translated `from_key` modality to `to_key` modality and c) reference reconstruction of the image VAE inside the XModalix.\n",
     "\n",
-    "For an example checkout the XModalix Tutorial"
+    "For an example checkout the [XModalix Tutorial](../PipelineTutorials/XModalix.ipynb)"
    ]
   },
   {

--- a/Tutorials/PipelineTutorials/Imagix.ipynb
+++ b/Tutorials/PipelineTutorials/Imagix.ipynb
@@ -7,14 +7,14 @@
    "source": [
     "# How To Use Imagix\n",
     "Imagix is our implementation of a variational autoencoder for image data.  \n",
-    "This tutorial follows the structure of `Getting Started - Vanillix`, but is much less extensive because our pipeline works similarly across different architectures. Here we focus only on Imagix specifics.\n",
+    "This tutorial follows the structure of [`Getting Started - Vanillix`](./Vanillix.ipynb), but is much less extensive because our pipeline works similarly across different architectures. Here we focus only on Imagix specifics.\n",
     "\n",
     "**AUTOENCODIX** supports far more functionality than shown here, so we’ll also point to advanced tutorials where relevant.  \n",
     "\n",
     "**IMPORTANT**\n",
     "\n",
     "> This tutorial only shows the specifics of the Imagix pipeline. If you're unfamiliar with general concepts,  \n",
-    "> we recommend following the `Getting Started - Vanillix` Tutorial first.\n",
+    "> we recommend following the [`Getting Started - Vanillix`](./Vanillix.ipynb) Tutorial first.\n",
     "\n",
     "## What You'll Learn\n",
     "\n",
@@ -1269,7 +1269,7 @@
     "The `result` object follows our standard interface. Refer to [1] for more details.  \n",
     "We don't have any `Imagix` specific results, but you can directly visualize the reconstructions as images, as shown in the code below:\n",
     "\n",
-    "[1] Tutorials/DeepDives/PipelineOutputTutorial.ipynb\n"
+    "[1] [Tutorials/DeepDives/PipelineOutputTutorial.ipynb](../DeepDives/PipelineOutputTutorial.ipynb)\n"
    ]
   },
   {
@@ -1417,7 +1417,7 @@
     "\n",
     "We can simply pass the architecture as type to the `model_type` parameter of the `Imagix` pipeline.\n",
     "\n",
-    "[2] Tutorials/DeepDives/ConfigTutorial.ipynb."
+    "[2] [Tutorials/DeepDives/ConfigTutorial.ipynb](../DeepDives/ConfigTutorial.ipynb)."
    ]
   },
   {

--- a/Tutorials/PipelineTutorials/Maskix.ipynb
+++ b/Tutorials/PipelineTutorials/Maskix.ipynb
@@ -17,7 +17,7 @@
     "**IMPORTANT**\n",
     "\n",
     "> This tutorial only shows the specifics of the Maskix pipeline. If you're unfamiliar with general concepts,  \n",
-    "> we recommend following the `Getting Started - Vanillix` tutorial first.\n",
+    "> we recommend following the [`Getting Started - Vanillix`](./Vanillix.ipynb) tutorial first.\n",
     "\n",
     "## What You'll Learn\n",
     "\n",
@@ -390,7 +390,7 @@
     "To investigate these losses, the `result` object has the attribute `sub_losses`.  \n",
     "This is a `LossRegistry` with the name of the loss as the key, and the value is a `TrainingDynamics` object, which can be accessed in the same way as for the Vanillix results.\n",
     "\n",
-    "For more details, check `Tutorials/DeepDives/PipelineOutputTutorial.ipynb`.\n"
+    "For more details, check [`Tutorials/DeepDives/PipelineOutputTutorial.ipynb`](../DeepDives/PipelineOutputTutorial.ipynb).\n"
    ]
   },
   {
@@ -428,7 +428,7 @@
    "metadata": {},
    "source": [
     "As for our other pipelines we can visualize the loss with `.show_result()`\n",
-    "For more infos on visualization, see: `Tutorials/DeepDives/VisualizeTutorial.ipynb`"
+    "For more infos on visualization, see: [`Tutorials/DeepDives/VisualizeTutorial.ipynb`](../DeepDives/VisualizeTutorial.ipynb)"
    ]
   },
   {
@@ -2568,8 +2568,8 @@
    "source": [
     "## 7) Save, Load and Re-Use Maskix\n",
     "\n",
-    "There are not `Maskix` specific steps here. See the `Tutorials/PipelineTutorials/Vanillix.ipynb\n",
-    "`  or `Tutorials/DeepDives/MemoryEfficientSaving.ipynb` for details. Below is a basic save/load usecase:"
+    "There are not `Maskix` specific steps here. See the [`Tutorials/PipelineTutorials/Vanillix.ipynb\n",
+    "`](./Vanillix.ipynb)  or [`Tutorials/DeepDives/MemoryEfficientSaving.ipynb`](../DeepDives/MemoryEfficientSaving.ipynb) for details. Below is a basic save/load usecase:"
    ]
   },
   {

--- a/Tutorials/PipelineTutorials/Ontix.ipynb
+++ b/Tutorials/PipelineTutorials/Ontix.ipynb
@@ -12,7 +12,7 @@
     "**IMPORTANT**\n",
     "\n",
     "> This tutorial only shows the specifics of the Ontix pipeline. If you're unfamiliar with general concepts,  \n",
-    "> we recommend following the `Getting Started - Vanillix` Tutorial first.\n",
+    "> we recommend following the [`Getting Started - Vanillix`](./Vanillix.ipynb) Tutorial first.\n",
     "\n",
     "## What You'll Learn\n",
     "\n",
@@ -51,7 +51,7 @@
     "\n",
     "### Extra 2: Get correct path\n",
     "We assume you are in the root of the package. The following code ensures that the correct paths are used.\n",
-    "[1] Tutorials/DeepDives/ConfigTutorial.ipynb"
+    "[1] [Tutorials/DeepDives/ConfigTutorial.ipynb](../DeepDives/ConfigTutorial.ipynb)"
    ]
   },
   {
@@ -1763,7 +1763,7 @@
    "metadata": {},
    "source": [
     "#### Obtain Results\n",
-    "If we're interested in working with latent spaces, reconstructions, or losses, we can access these for `Ontix` as for any other pipeline. For more details see `Tutorials/DeepDives/PipelineOutputTutorial.ipynb`.\n"
+    "If we're interested in working with latent spaces, reconstructions, or losses, we can access these for `Ontix` as for any other pipeline. For more details see [`Tutorials/DeepDives/PipelineOutputTutorial.ipynb`](../DeepDives/PipelineOutputTutorial.ipynb).\n"
    ]
   },
   {

--- a/Tutorials/PipelineTutorials/Stackix.ipynb
+++ b/Tutorials/PipelineTutorials/Stackix.ipynb
@@ -21,7 +21,7 @@
     "**IMPORTANT**\n",
     "\n",
     "> This tutorial only shows the specifics of the Stackix pipeline. If you're unfamiliar with general concepts,  \n",
-    "> we recommend following the `Getting Started - Vanillix` tutorial first.\n",
+    "> we recommend following the [`Getting Started - Vanillix`](./Vanillix.ipynb) tutorial first.\n",
     "\n",
     "## Stackix Theory\n",
     "\n",
@@ -63,7 +63,7 @@
     "\n",
     "We set a few custom parameters of the config file. For a deep dive into the config object, see:  \n",
     "\n",
-    "`Tutorials/DeepDives/ConfigTutorial.ipynb`\n",
+    "[`Tutorials/DeepDives/ConfigTutorial.ipynb`](../DeepDives/ConfigTutorial.ipynb)\n",
     "\n",
     "#### 1.1 The Dataset\n",
     "\n",
@@ -584,8 +584,8 @@
     "The value for each key is a `result` object analogous to the general result object.  \n",
     "These can be accessed via our standard API (see also [2]).\n",
     "\n",
-    "[1] `Tutorials/PipelineTutorials/Vanillix.ipynb`  \n",
-    "[2] `Tutorials/DeepDives/PipelineOutputTutorial.ipynb`\n"
+    "[1] [`Tutorials/PipelineTutorials/Vanillix.ipynb`](./Vanillix.ipynb)  \n",
+    "[2] [`Tutorials/DeepDives/PipelineOutputTutorial.ipynb`](../DeepDives/PipelineOutputTutorial.ipynb)\n"
    ]
   },
   {
@@ -2042,11 +2042,11 @@
     "## 4) Visualize Outputs\n",
     "\n",
     "This works exactly as for our other pipelines, by calling the `show_result` method.  \n",
-    "For more information, see our Visualization Deep Dive.  \n",
+    "For more information, see our [Visualization Deep Dive](../DeepDives/VisualizeTutorial.ipynb).  \n",
     "\n",
     "We can pass a column from the annotation file using the keyword argument `params` to color the plots according to this column.\n",
     "\n",
-    "[3] `Tutorials/DeepDives/VisualizeTutorial.ipynb`\n"
+    "[3] [`Tutorials/DeepDives/VisualizeTutorial.ipynb`](../DeepDives/VisualizeTutorial.ipynb)\n"
    ]
   },
   {

--- a/Tutorials/PipelineTutorials/Vanillix.ipynb
+++ b/Tutorials/PipelineTutorials/Vanillix.ipynb
@@ -78,8 +78,8 @@
     "All autoencoders share this unified pipeline interface, which we’ll explore in the next sections. <br><br>\n",
     "\n",
     "\n",
-    "[1] Tutorials/DeepDives/InputDataTutorials.ipynb <br>  \n",
-    "[2] Tutorials/PipelineTutorials/XModalix.ipynb <br>\n"
+    "[1] [Tutorials/DeepDives/InputDataTutorials.ipynb](../DeepDives/InputDataTutorials.ipynb) <br>  \n",
+    "[2] [Tutorials/PipelineTutorials/XModalix.ipynb](./XModalix.ipynb) <br>\n"
    ]
   },
   {
@@ -1645,10 +1645,10 @@
     "Now the data is ready to serve as input for our PyTorch models.  \n",
     "\n",
     "\n",
-    "[1] Tutorials/DeepDives/InputDataTutorials.ipynb <br>\n",
-    "[2] Tutorials/PipelineTutorials/XModalix.ipynb <br>\n",
-    "[3] Tutorials/PipelineTutorials/Stackix.ipynb <br>\n",
-    "[4] Tutorials/DeepDives/ConfigTutorial.ipynb <br>\n"
+    "[1] [Tutorials/DeepDives/InputDataTutorials.ipynb](../DeepDives/InputDataTutorials.ipynb) <br>\n",
+    "[2] [Tutorials/PipelineTutorials/XModalix.ipynb](./XModalix.ipynb) <br>\n",
+    "[3] [Tutorials/PipelineTutorials/Stackix.ipynb](./Stackix.ipynb) <br>\n",
+    "[4] [Tutorials/DeepDives/ConfigTutorial.ipynb](../DeepDives/ConfigTutorial.ipynb) <br>\n"
    ]
   },
   {
@@ -1693,7 +1693,7 @@
     "The training and model itself are highly customizable (`n_layers`, `latent_dim`, `epochs`, `learning_rate`, etc.). Refer to [Section 5](#5-customize) or Tutorial [4] for more details.  \n",
     "During training, we capture losses, latent spaces, and reconstructions for each checkpoint epoch and store them in our results object.\n",
     "\n",
-    "[4] Tutorials/DeepDives/ConfigTutorial.ipynb <br>\n"
+    "[4] [Tutorials/DeepDives/ConfigTutorial.ipynb](../DeepDives/ConfigTutorial.ipynb) <br>\n"
    ]
   },
   {
@@ -1848,7 +1848,7 @@
     "This step can also take a `data` argument, allowing you to run predictions on held-out data other than the test split.  \n",
     "If you provide new data, preprocessing will be applied automatically depending on the data format — see [1] for details.\n",
     "\n",
-    "[1] Tutorials/DeepDives/InputDataTutorials.ipynb\n"
+    "[1] [Tutorials/DeepDives/InputDataTutorials.ipynb](../DeepDives/InputDataTutorials.ipynb)\n"
    ]
   },
   {
@@ -2067,7 +2067,7 @@
     "In the basic case, you can specify a column in your annotation data to use for a machine learning task, e.g., training a classifier on disease state or cancer type. We then use the representations (latent space, UMAP, etc.) to train this classifier/regressor.  \n",
     "You have many options to customize this step for your needs, such as passing a scikit-learn model and defining evaluation metrics. Please refer to [5] for a complete guide.\n",
     "\n",
-    "[5] Tutorials/DeepDives/EvaluateTutorial.ipynb\n"
+    "[5] [Tutorials/DeepDives/EvaluateTutorial.ipynb](../DeepDives/EvaluateTutorial.ipynb)\n"
    ]
   },
   {
@@ -2150,7 +2150,7 @@
     "\n",
     "---\n",
     "For more details on how to work with TrainingDynamics and the Result object, refer to [5]\n",
-    "[5]Tutorials/DeepDives/PipelineOutputTutorial.ipynb \n",
+    "[5] [Tutorials/DeepDives/PipelineOutputTutorial.ipynb](../DeepDives/PipelineOutputTutorial.ipynb) \n",
     "\n"
    ]
   },
@@ -3530,7 +3530,7 @@
     "You can call the `show_result` method to display the actual plots. By passing the keyword argument `params` and providing a list of columns from the annotation data, you get visualizations based on these columns. In your example we use the `batch` column. This shows us if latent dimension are distributed differently per batch.  \n",
     "Refer to [5] for more details on how to work with plots.\n",
     "\n",
-    "[5] Tutorials/DeepDives/VisualizeTutorial.ipynb\n"
+    "[5] [Tutorials/DeepDives/VisualizeTutorial.ipynb](../DeepDives/VisualizeTutorial.ipynb)\n"
    ]
   },
   {
@@ -3604,7 +3604,7 @@
     "- Latent dimensions  \n",
     "- Retrieve information about all config parameters  \n",
     "\n",
-    "[4] Tutorials/DeepDives/ConfigTutorial.ipynb <br>\n"
+    "[4] [Tutorials/DeepDives/ConfigTutorial.ipynb](../DeepDives/ConfigTutorial.ipynb) <br>\n"
    ]
   },
   {

--- a/Tutorials/PipelineTutorials/Varix.ipynb
+++ b/Tutorials/PipelineTutorials/Varix.ipynb
@@ -16,7 +16,7 @@
     "**IMPORTANT**\n",
     "\n",
     "> This tutorial only shows the specifics of the Varix pipeline. If you're unfamiliar with general concepts,  \n",
-    "> we recommend following the `Getting Started - Vanillix` tutorial first.\n",
+    "> we recommend following the [`Getting Started - Vanillix`](./Vanillix.ipynb) tutorial first.\n",
     "\n",
     "## What You'll Learn\n",
     "\n",
@@ -41,7 +41,7 @@
     "\n",
     "We set a few custom parameters of the config file. For a deep dive into the config object, see:  \n",
     "\n",
-    "`Tutorials/DeepDives/ConfigTutorial.ipynb`\n",
+    "[`Tutorials/DeepDives/ConfigTutorial.ipynb`](../DeepDives/ConfigTutorial.ipynb)\n",
     "\n",
     "#### 1.1 The Dataset\n",
     "\n",
@@ -603,7 +603,7 @@
     "To investigate these losses, the `result` object has the attribute `sub_losses`.  \n",
     "This is a `LossRegistry` with the name of the loss as the key, and the value is a `TrainingDynamics` object, which can be accessed in the same way as for the Vanillix results.\n",
     "\n",
-    "For more details, check `Tutorials/DeepDives/PipelineOutputTutorial.ipynb`.\n"
+    "For more details, check [`Tutorials/DeepDives/PipelineOutputTutorial.ipynb`](../DeepDives/PipelineOutputTutorial.ipynb).\n"
    ]
   },
   {
@@ -756,7 +756,7 @@
     "1. Create a customized instance of the config class.  \n",
     "2. Provide a `yaml` file and use the config class to read it.  \n",
     "\n",
-    "We will focus on option 1 and show a few examples. For a deeper dive into configurations, please refer to `Tutorials/DeepDives/ConfigTutorial.ipynb` <br>\n",
+    "We will focus on option 1 and show a few examples. For a deeper dive into configurations, please refer to [`Tutorials/DeepDives/ConfigTutorial.ipynb`](../DeepDives/ConfigTutorial.ipynb) <br>\n",
     "\n",
     "In this section, we demonstrate some Varix-specific parameters:\n",
     "- Loss term  \n",

--- a/Tutorials/PipelineTutorials/XModalix.ipynb
+++ b/Tutorials/PipelineTutorials/XModalix.ipynb
@@ -8,14 +8,14 @@
     "# How To Use XModalix\n",
     "\n",
     "X-Modalix is our implementation of a cross-modal autoencoder.  \n",
-    "This tutorial follows the structure of `Getting Started - Vanillix`, but is less extensive because our pipeline works similarly across different architectures. Here, we focus only on X-Modalix specifics.\n",
+    "This tutorial follows the structure of [`Getting Started - Vanillix`](./Vanillix.ipynb), but is less extensive because our pipeline works similarly across different architectures. Here, we focus only on X-Modalix specifics.\n",
     "\n",
     "**AUTOENCODIX** supports far more functionality than shown here, so we’ll also point to advanced tutorials where relevant.  \n",
     "\n",
     "**IMPORTANT**\n",
     "\n",
     "> This tutorial only shows the specifics of the XModalix pipeline. If you're unfamiliar with general concepts,  \n",
-    "> we recommend following the `Getting Started - Vanillix` tutorial first.\n",
+    "> we recommend following the [`Getting Started - Vanillix`](./Vanillix.ipynb) tutorial first.\n",
     "\n",
     "## XModalix Theory\n",
     "\n",
@@ -85,7 +85,7 @@
     "\n",
     "### Extra 2: Get correct path\n",
     "We assume you are in the root of the package. The following code ensures that the correct paths are used.\n",
-    "[1] Tutorials/DeepDives/ConfigTutorial.ipynb"
+    "[1] [Tutorials/DeepDives/ConfigTutorial.ipynb](../DeepDives/ConfigTutorial.ipynb)"
    ]
   },
   {
@@ -597,8 +597,8 @@
     "\n",
     "For a more in-depth guide on the configuration parameters and input data, see:  \n",
     "\n",
-    "[1] `Tutorials/DeepDives/ConfigTutorial.ipynb`  \n",
-    "[2] `Tutorials/DeepDives/InputDataTutorials.ipynb`\n"
+    "[1] [`Tutorials/DeepDives/ConfigTutorial.ipynb`](../DeepDives/ConfigTutorial.ipynb)  \n",
+    "[2] [`Tutorials/DeepDives/InputDataTutorials.ipynb`](../DeepDives/InputDataTutorials.ipynb)\n"
    ]
   },
   {
@@ -1017,7 +1017,7 @@
     "\n",
     "See the code below for examples and [3] for more details:\n",
     "\n",
-    "[3] `Tutorials/DeepDives/PipelineOutputTutorial.ipynb`\n"
+    "[3] [`Tutorials/DeepDives/PipelineOutputTutorial.ipynb`](../DeepDives/PipelineOutputTutorial.ipynb)\n"
    ]
   },
   {


### PR DESCRIPTION
   Replace plain-text mentions of tutorial names/paths with relative
   markdown links to the corresponding notebooks, so cross-references
   between tutorials are clickable both locally and on GitHub

   Closes #170