### PR TITLE
 Fix crash on int-coded label columns in ridgeline plot

### DIFF
--- a/src/autoencodix/base/_base_pipeline.py
+++ b/src/autoencodix/base/_base_pipeline.py
@@ -106,7 +106,8 @@ class BasePipeline(abc.ABC):
             TypeError: If inputs have incorrect types.
         """
         if not hasattr(self, "_default_config"):
-            raise ValueError("""
+            raise ValueError(
+                """
                             The _default_config attribute has not been specified in your pipeline class.
 
                             Example:
@@ -116,7 +117,8 @@ class BasePipeline(abc.ABC):
                             _default_config in its corresponding pipeline class.
 
                             For more details, please refer to the 'how to add a new architecture' section in our documentation.
-                            """)
+                            """
+            )
         self.model_map = kwargs.pop("model_map", None)
         self._validate_config(config=config)
         self._validate_user_input(data=data)

--- a/src/autoencodix/visualize/_general_visualizer.py
+++ b/src/autoencodix/visualize/_general_visualizer.py
@@ -691,9 +691,19 @@ class GeneralVisualizer(BaseVisualizer):
 
         # print(labels[0])
         if not isinstance(labels[0], str):
-            if len(np.unique(labels)) > 3:
-                # Change all non-float labels to NaN
-                labels = [x if isinstance(x, float) else float("nan") for x in labels]
+            is_int_valued = all(
+                isinstance(x, (int, np.integer)) and not isinstance(x, bool)
+                for x in labels
+            )
+            if len(np.unique(labels)) > 3 and not is_int_valued:
+                # Coerce non-numeric entries to NaN, keep numeric values
+                labels = [
+                    x
+                    if isinstance(x, (int, float, np.integer, np.floating))
+                    and not isinstance(x, bool)
+                    else float("nan")
+                    for x in labels
+                ]
                 labels = list(
                     pd.qcut(
                         x=pd.Series(labels),

--- a/src/autoencodix/visualize/_general_visualizer.py
+++ b/src/autoencodix/visualize/_general_visualizer.py
@@ -487,8 +487,8 @@ class GeneralVisualizer(BaseVisualizer):
                             pd.qcut(
                                 x=pd.Series(labels),
                                 q=4,
-                            labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
-                        ).astype(str)
+                                labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
+                            ).astype(str)
                         )
                 else:
                     center = False  ## Disable centering for numeric params
@@ -711,8 +711,8 @@ class GeneralVisualizer(BaseVisualizer):
                         pd.qcut(
                             x=pd.Series(labels),
                             q=4,
-                        labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
-                    ).astype(str)
+                            labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
+                        ).astype(str)
                     )
             else:
                 labels = [str(x) for x in labels]

--- a/src/autoencodix/visualize/_general_visualizer.py
+++ b/src/autoencodix/visualize/_general_visualizer.py
@@ -473,18 +473,23 @@ class GeneralVisualizer(BaseVisualizer):
                     print(
                         "The provided label column is numeric and converted to categories."
                     )
-                    labels = [
-                        float("nan") if not isinstance(x, float) else x for x in labels
-                    ]
-                    labels = (
-                        pd.qcut(
-                            x=pd.Series(labels),
-                            q=4,
+                    # Try to convert all labels to float, if fails, convert to nan
+                    for i in range(len(labels)):
+                        try:
+                            labels[i] = float(labels[i])
+                        except ValueError:
+                            labels[i] = float("nan")
+                    # Check if all labels are NaN, convert to string
+                    if all(np.isnan(labels)):
+                        labels = [str(x) for x in labels]
+                    else:
+                        labels = list(
+                            pd.qcut(
+                                x=pd.Series(labels),
+                                q=4,
                             labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
+                        ).astype(str)
                         )
-                        .astype(str)
-                        .to_list()
-                    )
                 else:
                     center = False  ## Disable centering for numeric params
                     numeric = True
@@ -691,28 +696,24 @@ class GeneralVisualizer(BaseVisualizer):
 
         # print(labels[0])
         if not isinstance(labels[0], str):
-            is_int_valued = all(
-                isinstance(x, (int, np.integer)) and not isinstance(x, bool)
-                for x in labels
-            )
-            if len(np.unique(labels)) > 3 and not is_int_valued:
-                # Coerce non-numeric entries to NaN, keep numeric values
-                labels = [
-                    (
-                        x
-                        if isinstance(x, (int, float, np.integer, np.floating))
-                        and not isinstance(x, bool)
-                        else float("nan")
-                    )
-                    for x in labels
-                ]
-                labels = list(
-                    pd.qcut(
-                        x=pd.Series(labels),
-                        q=4,
+            if len(np.unique(labels)) > 3:
+                # Try to convert all labels to float, if fails, convert to nan
+                for i in range(len(labels)):
+                    try:
+                        labels[i] = float(labels[i])
+                    except ValueError:
+                        labels[i] = float("nan")
+                # Check if all labels are NaN, convert to string
+                if all(np.isnan(labels)):
+                    labels = [str(x) for x in labels]
+                else:
+                    labels = list(
+                        pd.qcut(
+                            x=pd.Series(labels),
+                            q=4,
                         labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
                     ).astype(str)
-                )
+                    )
             else:
                 labels = [str(x) for x in labels]
 

--- a/src/autoencodix/visualize/_general_visualizer.py
+++ b/src/autoencodix/visualize/_general_visualizer.py
@@ -698,10 +698,12 @@ class GeneralVisualizer(BaseVisualizer):
             if len(np.unique(labels)) > 3 and not is_int_valued:
                 # Coerce non-numeric entries to NaN, keep numeric values
                 labels = [
-                    x
-                    if isinstance(x, (int, float, np.integer, np.floating))
-                    and not isinstance(x, bool)
-                    else float("nan")
+                    (
+                        x
+                        if isinstance(x, (int, float, np.integer, np.floating))
+                        and not isinstance(x, bool)
+                        else float("nan")
+                    )
                     for x in labels
                 ]
                 labels = list(

--- a/src/autoencodix/visualize/_xmodal_visualizer.py
+++ b/src/autoencodix/visualize/_xmodal_visualizer.py
@@ -695,13 +695,24 @@ class XModalVisualizer(BaseVisualizer):
         # print(labels[0])
         if not isinstance(labels[0], str):
             if len(np.unique(labels)) > 3:
-                # Change all non-float labels to NaN
-                labels = [x if isinstance(x, float) else float("nan") for x in labels]
-                labels = pd.qcut(
-                    x=pd.Series(labels),
-                    q=4,
-                    labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
-                ).astype(str)
+                # Try to convert all labels to float, if fails, convert to nan
+                for i in range(len(labels)):
+                    try:
+                        labels[i] = float(labels[i])
+                    except ValueError:
+                        labels[i] = float("nan")
+                # Check if all labels are NaN, convert to string
+                if all(np.isnan(labels)):
+                    labels = [str(x) for x in labels]
+                else:
+                    labels = list(
+                        pd.qcut(
+                            x=pd.Series(labels),
+                            q=4,
+                        labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
+                    ).astype(str)
+                    )
+                
             else:
                 labels = [str(x) for x in labels]
 

--- a/src/autoencodix/visualize/_xmodal_visualizer.py
+++ b/src/autoencodix/visualize/_xmodal_visualizer.py
@@ -709,10 +709,10 @@ class XModalVisualizer(BaseVisualizer):
                         pd.qcut(
                             x=pd.Series(labels),
                             q=4,
-                        labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
-                    ).astype(str)
+                            labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
+                        ).astype(str)
                     )
-                
+
             else:
                 labels = [str(x) for x in labels]
 

--- a/src/autoencodix/visualize/visualize.py
+++ b/src/autoencodix/visualize/visualize.py
@@ -718,8 +718,8 @@ class Visualizer(BaseVisualizer):
                             pd.qcut(
                                 x=pd.Series(labels),
                                 q=4,
-                            labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
-                        ).astype(str)
+                                labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
+                            ).astype(str)
                         )
                 else:
                     center = False  ## Disable centering for numeric params
@@ -852,8 +852,8 @@ class Visualizer(BaseVisualizer):
                         pd.qcut(
                             x=pd.Series(labels),
                             q=4,
-                        labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
-                    ).astype(str)
+                            labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
+                        ).astype(str)
                     )
             else:
                 labels = [str(x) for x in labels]

--- a/src/autoencodix/visualize/visualize.py
+++ b/src/autoencodix/visualize/visualize.py
@@ -704,19 +704,23 @@ class Visualizer(BaseVisualizer):
                     print(
                         "The provided label column is numeric and converted to categories."
                     )
-                    # Change non-float labels to NaN
-                    labels = [
-                        x if isinstance(x, float) else float("nan") for x in labels
-                    ]
-                    labels = (
-                        pd.qcut(
-                            x=pd.Series(labels),
-                            q=4,
+                    # Try to convert all labels to float, if fails, convert to nan
+                    for i in range(len(labels)):
+                        try:
+                            labels[i] = float(labels[i])
+                        except ValueError:
+                            labels[i] = float("nan")
+                    # Check if all labels are NaN, convert to string
+                    if all(np.isnan(labels)):
+                        labels = [str(x) for x in labels]
+                    else:
+                        labels = list(
+                            pd.qcut(
+                                x=pd.Series(labels),
+                                q=4,
                             labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
+                        ).astype(str)
                         )
-                        .astype(str)
-                        .to_list()
-                    )
                 else:
                     center = False  ## Disable centering for numeric params
                     numeric = True
@@ -834,13 +838,23 @@ class Visualizer(BaseVisualizer):
         # print(labels[0])
         if not isinstance(labels[0], str):
             if len(np.unique(labels)) > 3:
-                # Change non-float labels to NaN
-                labels = [x if isinstance(x, float) else float("nan") for x in labels]
-                labels = pd.qcut(
-                    x=pd.Series(labels),
-                    q=4,
-                    labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
-                ).astype(str)
+                # Try to convert all labels to float, if fails, convert to nan
+                for i in range(len(labels)):
+                    try:
+                        labels[i] = float(labels[i])
+                    except ValueError:
+                        labels[i] = float("nan")
+                # Check if all labels are NaN, convert to string
+                if all(np.isnan(labels)):
+                    labels = [str(x) for x in labels]
+                else:
+                    labels = list(
+                        pd.qcut(
+                            x=pd.Series(labels),
+                            q=4,
+                        labels=["1stQ", "2ndQ", "3rdQ", "4thQ"],
+                    ).astype(str)
+                    )
             else:
                 labels = [str(x) for x in labels]
 


### PR DESCRIPTION
#### Problem
  - Fixes a crash in `GeneralVisualizer._plot_latent_ridge` when coloring a Ridgeline plot by an integer-coded categorical label column (e.g. class labels) with more than 3 unique values.
  - Cause of crash: the function used isinstance(x, float) to decide which label values were valid numbers before quantile-binning. int values fail that check and were coerced to NaN. Problem: When all values in a label column are integers (which is the case for example for the MNIST dataset mapping labels), the entire series became NaN and `pd.qcut` raised ValueError: Bin edges must be unique because every computed bin edge was NaN.
  - Fix suggested in this PR: label columns that are only integer-valued (no floats mixed in) are now treated as categorical directly, skipping the quantile-binning branch entirely. Columns that do contain genuine float values keep the
    existing quantile-binning behavior and non-numeric outliers within such columns are still coerced to NaN like before.
- this means that there is a behavior change for float columns which have `int` values mixed into them then these values are no longer dropped to NaN.

#### Limitations
- the crash hasn't happend before since every other tutorial currently colors by a string-typed column (eg. cancer_type, cell_type, disease...)
- however possible problem with this fix could be: a column that is integer-valued but semantically continuous (like age in years without missing values) will now be treated as categorical rather than quantile-binned

- Instead of this handling it would also be possible to simply extend the numeric check to include int, not just float, to prevent the crash
